### PR TITLE
Fix for uloz.to filename

### DIFF
--- a/ulozto_downloader.py
+++ b/ulozto_downloader.py
@@ -65,7 +65,7 @@ def parse_page(url):
         raise RuntimeError("File was deleted from Uloz.to")
 
     # Parse filename only to the first | (Uloz.to sometimes add titles like "name | on-line video | Ulož.to" and so on)
-    filename = parse_single(r.text, r'<title>([^\|]*)\s+\|.*</title>')
+    filename = parse_single(r.text, r'<title>([^\|]*)\s+\|.*</title>').replace("/", "-")
 
     # Some files may be download without CAPTCHA, there is special URL on the parsed page:
     # <a ... href="/slowDownload/E7jJsmR2ix73">...</a>


### PR DESCRIPTION
When file name contains slash, file is not downloaded due to

```
  File "/usr/lib64/python3.6/multiprocessing/process.py", line 258, in _bootstrap
    self.run()  Waiting for CAPTCHA...
  File "/usr/lib64/python3.6/multiprocessing/process.py", line 93, in run
    self._target(*self._args, **self._kwargs)
  File "./ulozto_downloader.py", line 237, in download_part
    with open(part['filename'], 'ab') as f:
FileNotFoundError: [Errno 2] No such file or directory: "bla-bla-with-slash"
```